### PR TITLE
add a simple json serializer for response

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -1,24 +1,15 @@
-[app:mydummyapp]
+[app:main]
 use = egg:dummy_app
 pyramid.reload_templates = true
 #pyramid.includes = pyramid_debugtoolbar
-
-[filter:translogger]
-use = egg:Paste#translogger
-setup_console_handler = False
-
-[pipeline:main]
-pipeline = translogger
-           mydummyapp
 
 [server:main]
 use = egg:waitress#main
 listen = localhost:6543
 
 # Begin logging configuration
-
 [loggers]
-keys = root, dummy_app, wsgi
+keys = root, dummy_app, json
 
 [logger_root]
 level = INFO
@@ -26,14 +17,13 @@ handlers = console
 
 [logger_dummy_app]
 level = DEBUG
-handlers = console, sqlalchemy
+handlers = console
 qualname = dummy_app
 
-[logger_wsgi]
+[logger_json]
 level = INFO
 handlers = console, sqlalchemy
-qualname = wsgi
-propagate = 0
+qualname = JSON
 
 [handlers]
 keys = console, sqlalchemy
@@ -46,8 +36,9 @@ formatter = generic
 
 [handler_sqlalchemy]
 class = sqlalchemylogger.handlers.SQLAlchemyHandler
+args = ({'url':'sqlite:///logger_db.sqlite3','tablename':'test'},)
 #args = ({'url':'sqlite:///logger_db.sqlite3','tablename':'test'},'curl')
-args = ({'url':'postgresql://postgres:password@localhost:5432/test','tablename':'test','tableargs': {'schema':'xyz'}},'curl')
+#args = ({'url':'postgresql://postgres:password@localhost:5432/test','tablename':'test','tableargs': {'schema':'xyz'}},'curl')
 level = NOTSET
 formatter = generic
 propagate = 0

--- a/development.ini
+++ b/development.ini
@@ -9,7 +9,7 @@ listen = localhost:6543
 
 # Begin logging configuration
 [loggers]
-keys = root, dummy_app, json
+keys = root, dummy_app
 
 [logger_root]
 level = INFO
@@ -22,11 +22,11 @@ qualname = dummy_app
 
 [logger_json]
 level = INFO
-handlers = console, sqlalchemy
+handlers = console, sqlalchemy_logger
 qualname = JSON
 
 [handlers]
-keys = console, sqlalchemy
+keys = console
 
 [handler_console]
 class = StreamHandler
@@ -34,11 +34,11 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 
-[handler_sqlalchemy]
+[handler_sqlalchemy_logger]
 class = sqlalchemylogger.handlers.SQLAlchemyHandler
 args = ({'url':'sqlite:///logger_db.sqlite3','tablename':'test'},)
 #args = ({'url':'sqlite:///logger_db.sqlite3','tablename':'test'},'curl')
-#args = ({'url':'postgresql://postgres:password@localhost:5432/test','tablename':'test','tableargs': {'schema':'xyz'}},'curl')
+#args = ({'url':'postgresql://postgres:password@localhost:5432/test','tablename':'test','tableargs': {'schema':'xyz','extend_existing': True}},)
 level = NOTSET
 formatter = generic
 propagate = 0

--- a/dummy_app/__init__.py
+++ b/dummy_app/__init__.py
@@ -6,6 +6,7 @@ def main(global_config, **settings):
     config.include('pyramid_chameleon')
     config.add_route('home', '/')
     config.add_route('hello', '/howdy')
+    config.add_route('fail', '/fail')
     config.scan('.views')
     app = config.make_wsgi_app()
 #    app = TransLogger(app, setup_console_handler=False)

--- a/dummy_app/decorators.py
+++ b/dummy_app/decorators.py
@@ -1,6 +1,5 @@
 
 import logging
-import time
 import json
 
 log = logging.getLogger('JSON')
@@ -30,3 +29,20 @@ def _serialize_request(request):
     x['path']=str(request.path)
     x['view_name']=str(request.view_name)
     return {'request': x}
+
+
+class OerebStats(object):
+    stats={}
+    def __init__(self,
+                 service=None,
+                 output_format=None,
+                 location=None,
+                 flavour=None):
+           self.stats['service']=service
+           self.stats['output_format']=output_format
+           self.stats['location']=location
+           self.stats['flavour']=flavour
+
+    def __repr__(self):
+         json.dumps(self.stats)
+

--- a/dummy_app/decorators.py
+++ b/dummy_app/decorators.py
@@ -1,0 +1,23 @@
+
+import logging
+import time
+import json
+
+log = logging.getLogger('JSON')
+
+def log_response(wrapped):
+    def wrapper(context, request):
+        response = wrapped(context, request)
+        log.info(_serialize_response(response))
+        return response
+    return wrapper
+
+
+def _serialize_response(response):
+    x = {}
+    x['status']=response.status
+    x['headers']=dict(response.headers)
+    x['body']=str(response.body)
+    y = {'response': x}
+    return json.dumps(y)
+

--- a/dummy_app/decorators.py
+++ b/dummy_app/decorators.py
@@ -8,7 +8,10 @@ log = logging.getLogger('JSON')
 def log_response(wrapped):
     def wrapper(context, request):
         response = wrapped(context, request)
-        log.info(_serialize_response(response))
+#        import ipdb; ipdb.set_trace()
+        ret_dict = _serialize_response(response)
+        ret_dict.update(_serialize_request(request))
+        log.info(json.dumps(ret_dict))
         return response
     return wrapper
 
@@ -17,7 +20,13 @@ def _serialize_response(response):
     x = {}
     x['status']=response.status
     x['headers']=dict(response.headers)
-    x['body']=str(response.body)
-    y = {'response': x}
-    return json.dumps(y)
+    return {'response': x}
 
+def _serialize_request(request):
+    x = {}
+    x['headers']=dict(request.headers)
+    x['traversed']=str(request.traversed)
+    x['parameters']=dict(request.GET)
+    x['path']=str(request.path)
+    x['view_name']=str(request.view_name)
+    return {'request': x}

--- a/dummy_app/views.py
+++ b/dummy_app/views.py
@@ -1,5 +1,5 @@
 import logging
-from .decorators import log_response
+from .decorators import log_response, OerebStats
 log = logging.getLogger(__name__)
 from pyramid.response import Response
 from pyramid.view import (
@@ -14,7 +14,6 @@ class TutorialViews:
     def __init__(self, request):
         self.request = request
 
-
     @view_config(route_name='home')
     def home(self):
         log.debug('In home view')
@@ -25,13 +24,6 @@ class TutorialViews:
         log.debug('In hello view')
         return {'name': 'Hello View'}
 
-def _serialize_res(request):
-    x = {}
-    x['status']=response.status
-    x['headers']=dict(response.headers)
-    x['body']=str(response.body)
-    y = {'response': x}
-    return json.dumps(y)
 
 @notfound_view_config(decorator = log_response)
 def notfound_get(request):

--- a/dummy_app/views.py
+++ b/dummy_app/views.py
@@ -1,9 +1,10 @@
 import logging
 from .decorators import log_response
 log = logging.getLogger(__name__)
-
+from pyramid.response import Response
 from pyramid.view import (
     view_config,
+    notfound_view_config,
     view_defaults
     )
 
@@ -24,3 +25,14 @@ class TutorialViews:
         log.debug('In hello view')
         return {'name': 'Hello View'}
 
+def _serialize_res(request):
+    x = {}
+    x['status']=response.status
+    x['headers']=dict(response.headers)
+    x['body']=str(response.body)
+    y = {'response': x}
+    return json.dumps(y)
+
+@notfound_view_config(decorator = log_response)
+def notfound_get(request):
+    return Response('Not Found', status='404 Not Found')

--- a/dummy_app/views.py
+++ b/dummy_app/views.py
@@ -1,4 +1,5 @@
 import logging
+from .decorators import log_response
 log = logging.getLogger(__name__)
 
 from pyramid.view import (
@@ -6,10 +7,12 @@ from pyramid.view import (
     view_defaults
     )
 
-@view_defaults(renderer='home.pt')
+
+@view_defaults(renderer='home.pt',decorator = log_response)
 class TutorialViews:
     def __init__(self, request):
         self.request = request
+
 
     @view_config(route_name='home')
     def home(self):

--- a/dummy_app/views.py
+++ b/dummy_app/views.py
@@ -7,7 +7,7 @@ from pyramid.view import (
     notfound_view_config,
     view_defaults
     )
-
+from pyramid.httpexceptions import HTTPBadRequest, HTTPNoContent, HTTPServerError, HTTPNotFound
 
 @view_defaults(renderer='home.pt',decorator = log_response)
 class TutorialViews:
@@ -28,3 +28,13 @@ class TutorialViews:
 @notfound_view_config(decorator = log_response)
 def notfound_get(request):
     return Response('Not Found', status='404 Not Found')
+
+class Fail:
+    def __init__(self,request):
+        self.request = request
+    
+    @view_config(route_name='fail')
+    def samere(self):
+         response = HTTPBadRequest('this request always fails',json_formatter='json')
+         import ipdb; ipdb.set_trace()
+         return response


### PR DESCRIPTION
this PR add a json serializer for a pyramid.Response in the form of a simple decorator.

in the current state the project uses the sqlalchemy handler to push the JSON serialized logs to an sqlite DB.

To test:
```shell
make install
make serve

# from another terminal:
curl localhost:6543/
# you should get some logs in the console, and the JSON one should also be in the sqlite DB:
sqlite3 logger_db.sqlite3
sqlite> SELECT * FROM test;
```

ping @jwkaltz

 